### PR TITLE
Fix maillist link

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,10 +70,9 @@
       <ul class="nav nav-pills pull-right">
         <li role="presentation" class="active"><a href="/">Inicial</a></li>
         <li role="presentation"><a href="#download">Download</a></li>
-        <li role="presentation"><a href="https://openbsd-br.org/mailman/listinfo/lista">Lista</a></li>
+        <li role="presentation"><a href="https://www.openbsd.org/mail.html">Lista de Email Oficial</a></li>
         <li role="presentation"><a href="https://web.libera.chat/#openbsd-br" target="_blank">IRC</a></li>
         <li role="presentation"><a href="artwork.html">Artwork</a></li>
-        <li role="presentation"><a href="/faq/">FAQ</a></li>
         <li role="presentation"><a href="https://openbsd.org" target="_blank">Site Oficial</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
* Remove broken Maillist BR and add the link to the official maillist instead
* Remove FAQ section since it was returning 404